### PR TITLE
Switch to migrated drop_cap_text fork

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -108,11 +108,12 @@ packages:
   drop_cap_text:
     dependency: "direct main"
     description:
-      name: drop_cap_text
-      sha256: "9839d788ad6600c6c374fbc995a3cf784bbe9bf1823bcfa7dc49c4c50d918757"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.1.3"
+      path: "."
+      ref: "feat/adapt-for-deprecations"
+      resolved-ref: "224785fa7825a43f44228531ceed398c47d7bf23"
+      url: "https://github.com/parlough/drop_cap_text"
+    source: git
+    version: "1.2.0"
   equatable:
     dependency: "direct main"
     description:
@@ -186,10 +187,10 @@ packages:
     dependency: "direct dev"
     description:
       name: flutter_lints
-      sha256: e2a421b7e59244faef694ba7b30562e489c2b489866e505074eb005cd7060db7
+      sha256: "9e8c3858111da373efc5aa341de011d9bd23e2c5c5e0c62bccf32438e192d7b1"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.1"
+    version: "3.0.2"
   flutter_localizations:
     dependency: "direct main"
     description: flutter
@@ -268,10 +269,10 @@ packages:
     dependency: "direct main"
     description:
       name: go_router
-      sha256: "7ecb2f391edbca5473db591b48555a8912dde60edd0fb3013bd6743033b2d3f8"
+      sha256: "5ed2687bc961f33a752017ccaa7edead3e5601b28b6376a5901bf24728556b85"
       url: "https://pub.dev"
     source: hosted
-    version: "13.2.1"
+    version: "13.2.2"
   home_widget:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,7 +17,10 @@ dependencies:
   collection: ^1.17.0
   cupertino_icons: ^1.0.5
   desktop_window: ^0.4.0
-  drop_cap_text: ^1.1.3
+  drop_cap_text:
+    git:
+      url: https://github.com/parlough/drop_cap_text
+      ref: feat/adapt-for-deprecations
   equatable: ^2.0.5
   extra_alignments: ^1.0.0+1
   flextras: ^1.0.0


### PR DESCRIPTION
Switches `drop_cap_text` to a fork I migrated: https://github.com/mtiziano/drop_cap_text/pull/25